### PR TITLE
fix: Use popleft for event queue and pop(0) for waiting_coro in MainLoop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,14 @@ dist: trusty
 before_install:
     - sudo apt-get install -y git make g++ python3 python3-numpy python3-dev libgoogle-glog-dev verilator
 script:
+    - python3 -m pip install pytest
     - python3 setup.py install --user
+    - pytest tests
     - cd sim
     - ./test_all_verilator.sh
     - cd standalone
     - ./test_all.sh
+
 branches:
     only:
         - master

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,4 +1,6 @@
 # Copyright (C) 2017-2019, Yu Sheng Lin, johnjohnlys@media.ee.ntu.edu.tw
+# Contributors
+# 2023, En Ho Shen, enhoshen@gmail.com
 
 # This file is part of Nicotb.
 

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -72,12 +72,12 @@ def RegisterCoroutines(coro: list):
 
 def MainLoop():
 	while len(event_queue) != 0:
-		event_idx, all_ev = event_queue.pop()
+		event_idx, all_ev = event_queue.popleft()
 		if all_ev:
 			proc = waiting_coro[event_idx]
 			waiting_coro[event_idx] = list()
 		else:
-			proc = [waiting_coro.pop()]
+			proc = [waiting_coro.pop(0)]
 		RegisterCoroutines(proc)
 
 def FinishSim():

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (C) 2017-2019, Yu Sheng Lin, johnjohnlys@media.ee.ntu.edu.tw
+
+# This file is part of Nicotb.
+
+# Nicotb is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Nicotb is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with Nicotb.  If not, see <http://www.gnu.org/licenses/>.
+

--- a/tests/test_main_loop.py
+++ b/tests/test_main_loop.py
@@ -1,4 +1,7 @@
 # Copyright (C) 2017-2019, Yu Sheng Lin, johnjohnlys@media.ee.ntu.edu.tw
+# Contributors
+# 2023, Chun Kuan Tsai, cktsai@ganzin.com.tw
+# 2023, En Ho Shen, enhoshen@gmail.com
 
 # This file is part of Nicotb.
 

--- a/tests/test_main_loop.py
+++ b/tests/test_main_loop.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2017-2019, Yu Sheng Lin, johnjohnlys@media.ee.ntu.edu.tw
+
+# This file is part of Nicotb.
+
+# Nicotb is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Nicotb is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with Nicotb.  If not, see <http://www.gnu.org/licenses/>.
+
+import nicotb
+
+class TestMainLoop:
+    def test_event_fifo(self):
+        # verify if the events are always handled in the order
+        # they are pushed into the queue
+        ev = [nicotb.CreateEvent() for i in range(3)]
+
+        result = []
+        def coro(ev):
+            # wait for event and append the event to result
+            yield ev
+            result.append(ev)
+            
+        def main():
+            # fork two events then trigger them in order
+            for i in range(3):
+                nicotb.Fork(coro(ev[i]))
+
+            for i in range(3):
+                nicotb.SignalEvent(ev[i])
+            yield None
+
+        nicotb.Fork(main())
+        nicotb.MainLoop()
+
+        assert result == ev
+


### PR DESCRIPTION
# Description
Event queue pop latest added event first if the pushed events happens in one procedure call.
Use `popleft` for `deque` and `pop(0)` for `list` instead.

# Notes
Closes #1.